### PR TITLE
chore: complete ruff rule set (annotations + judgment batch)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,8 @@ line-length = 120
 target-version = "py310"
 
 [tool.ruff.lint]
-# The reference rule set is rolled out in batches (each batch lands green):
-#   batch 1 (here): mechanical / autofix families
-#   batch 2: D      (docstrings)
-#   batch 3: ANN, N, PT, B, S, C901  (annotations + judgment/behavior cases)
+# Broad rule set; PLC/PLR (pylint conventions/refactors) are deliberately excluded as
+# noisy on this numerical domain, and specific carve-outs live in `ignore` below.
 select = [
     "F",       # pyflakes
     "E", "W",  # pycodestyle (incl. E501 line-too-long)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,18 @@ select = [
     "FLY",     # flynt: static str-join → f-string
     "INP",     # flake8-no-pep420: every package dir has an __init__.py
     "D",       # pydocstyle (Google convention)
+    "B",       # flake8-bugbear
+    "N",       # pep8-naming
+    "PT",      # flake8-pytest-style
+    "ANN",     # flake8-annotations
+    "SLF",     # flake8-self: private-member access
+    "S",       # flake8-bandit: security lint
+    "C901",    # mccabe complexity gate (threshold in [tool.ruff.lint.mccabe])
 ]
 ignore = [
     "RUF001", "RUF002", "RUF003",  # intentional typography, not "ambiguous"
     "RUF007",  # numba nopython mode can't compile itertools.pairwise; keep zip(x[:-1], x[1:])
+    "B905",    # numba nopython mode can't take zip()'s strict= kwarg
 ]
 
 [tool.ruff.lint.mccabe]
@@ -91,11 +99,18 @@ max-complexity = 10
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.ruff.lint.flake8-pytest-style]
+parametrize-names-type = "csv"                     # names given as a single "a, b" string
+raises-require-match-for = ["Exception", "BaseException"]  # only the truly broad base exceptions need match=
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["SLF001", "S101", "S311", "D", "ANN"]  # AAA tests: asserts, private access, random data, no docstring/annotation duty
 "__init__.py" = ["F401"]                 # re-export modules: naked imports, no `as` alias
 ".github/scripts/**" = ["INP001", "S", "D", "ANN"]   # maintainer tooling, not held to shipped-source style
-"notebooks/**" = ["INP001", "S", "D", "ANN", "E501", "PTH", "PLW2901"]  # exploratory notebooks, not held to shipped-source style
+"notebooks/**" = ["INP001", "S", "D", "ANN", "E501", "PTH", "PLW2901", "B"]  # exploratory notebooks, not held to shipped-source style
+# @cache on FunctionSampler's computed-array methods is deliberate; the resulting instance
+# retention is tracked as a parked behavior item, not silently refactored here.
+"snuffled/_core/analysis/_function_sampler.py" = ["B019"]
 
 [tool.coverage.run]
 source = ["snuffled"]

--- a/snuffled/_core/analysis/_function_sampler.py
+++ b/snuffled/_core/analysis/_function_sampler.py
@@ -33,7 +33,7 @@ class FunctionSampler:
         n_fun_samples: int = 1_000,
         n_roots: int = 100,
         rel_tol_scale: float = 10.0,
-    ):
+    ) -> None:
         # --- randomization -------------------------------
         self._seed = seed + SEED_OFFSET_FUNCTION_SAMPLER
 

--- a/snuffled/_core/analysis/_property_extractor.py
+++ b/snuffled/_core/analysis/_property_extractor.py
@@ -13,7 +13,7 @@ class PropertyExtractor(ABC, Generic[NA]):
     # =================================================================================================
     #  Main API
     # =================================================================================================
-    def __init__(self, function_sampler: FunctionSampler):
+    def __init__(self, function_sampler: FunctionSampler) -> None:
         self.function_sampler = function_sampler
         self.__stats: dict[str, PropertyExtractionStats] = {}  # property -> stats
 

--- a/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
+++ b/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
@@ -9,7 +9,7 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self, function_sampler: FunctionSampler):
+    def __init__(self, function_sampler: FunctionSampler) -> None:
         super().__init__(function_sampler)
 
     # -------------------------------------------------------------------------

--- a/snuffled/_core/analysis/function/function_analyser.py
+++ b/snuffled/_core/analysis/function/function_analyser.py
@@ -15,7 +15,7 @@ class FunctionAnalyser(PropertyExtractor[SnuffledFunctionProperties]):
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self, function_sampler: FunctionSampler):
+    def __init__(self, function_sampler: FunctionSampler) -> None:
         super().__init__(function_sampler)
 
     # -------------------------------------------------------------------------

--- a/snuffled/_core/analysis/function/helpers_discontinuous.py
+++ b/snuffled/_core/analysis/function/helpers_discontinuous.py
@@ -123,7 +123,7 @@ def discontinuity_score(function_sampler: FunctionSampler, n_samples: int) -> fl
         def heuristic(_dx: float, _dfx: float) -> float:
             if _dx > dx_min:
                 _dx_rel = _dx / dx_total
-                _dfx_rel = _dfx / dfx_total
+                _dfx_rel = _dfx / dfx_total  # noqa: B023 -- called immediately in-iteration; no late binding
                 return (_dfx_rel * _dfx_rel / _dx_rel) + (_dx_rel * _dx_rel)
             return 0.0
 

--- a/snuffled/_core/analysis/roots/curve_fitting/specialized/_explore_uncertainty.py
+++ b/snuffled/_core/analysis/roots/curve_fitting/specialized/_explore_uncertainty.py
@@ -7,7 +7,7 @@ from ._helpers import param_step
 
 
 @numba.njit
-def explore_uncertainty(
+def explore_uncertainty(  # noqa: C901 -- inherent branching in the bisection-based uncertainty exploration
     x: np.ndarray,
     fx: np.ndarray,
     a_opt: float,

--- a/snuffled/_core/analysis/roots/curve_fitting/specialized/_helpers.py
+++ b/snuffled/_core/analysis/roots/curve_fitting/specialized/_helpers.py
@@ -14,7 +14,9 @@ __LN_R = math.log(2 * math.sqrt(2))  # ln(r) with r = 2*math.sqrt(2)
 #  Parameter initialization
 # =================================================================================================
 @numba.njit(inline="always")
-def initialize_params(range_a: tuple[float, float], range_b: tuple[float, float], range_c: tuple[float, float]):
+def initialize_params(
+    range_a: tuple[float, float], range_b: tuple[float, float], range_c: tuple[float, float]
+) -> tuple[float, float, float]:
     """Return acceptable parameters within ranges."""
     # A: geometric mid-point of range (range_a values should always be positive)
     a = math.sqrt(range_a[0] * range_a[1])

--- a/snuffled/_core/analysis/roots/roots_analyser.py
+++ b/snuffled/_core/analysis/roots/roots_analyser.py
@@ -17,7 +17,7 @@ class RootsAnalyser(PropertyExtractor[SnuffledRootProperties]):
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self, function_sampler: FunctionSampler, n_root_samples: int, seed: int):
+    def __init__(self, function_sampler: FunctionSampler, n_root_samples: int, seed: int) -> None:
         super().__init__(function_sampler)
         self.n_root_samples = n_root_samples
         self._root_analyses: dict[Root, SnuffledRootProperties] = {}
@@ -46,7 +46,7 @@ class RootsAnalyser(PropertyExtractor[SnuffledRootProperties]):
     # -------------------------------------------------------------------------
     #  Internal methods
     # -------------------------------------------------------------------------
-    def _ensure_all_roots_analysed(self):
+    def _ensure_all_roots_analysed(self) -> None:
         roots = self.function_sampler.roots()
         if len(self._root_analyses) < len(roots):
             self._root_analyses = {

--- a/snuffled/_core/analysis/roots/single_root_one_side_analyser.py
+++ b/snuffled/_core/analysis/roots/single_root_one_side_analyser.py
@@ -28,7 +28,7 @@ class SingleRootOneSideAnalyser:
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self, dx: float, x_deltas: np.ndarray, fx_values: np.ndarray, dx_sign: int, fx_sign: int):
+    def __init__(self, dx: float, x_deltas: np.ndarray, fx_values: np.ndarray, dx_sign: int, fx_sign: int) -> None:
         """Initialize the single-root one-side analyser.
 
         :param dx: (float > 0) dx-value used to generate x_deltas

--- a/snuffled/_core/analysis/roots/single_root_two_side_analyser.py
+++ b/snuffled/_core/analysis/roots/single_root_two_side_analyser.py
@@ -22,7 +22,7 @@ class SingleRootTwoSideAnalyser(PropertyExtractor[SnuffledRootProperties]):
         root: Root,
         n_root_samples: int,
         seed: int,
-    ):
+    ) -> None:
         super().__init__(function_sampler)
         self.root = root
         self.dx = function_sampler.dx
@@ -37,7 +37,7 @@ class SingleRootTwoSideAnalyser(PropertyExtractor[SnuffledRootProperties]):
     # -------------------------------------------------------------------------
     #  Internal - Root Analysis
     # -------------------------------------------------------------------------
-    def _perform_analyses(self):
+    def _perform_analyses(self) -> None:
         """Performs left- and right-sided root analysis and populates self._analysis_left, self._analysis_right."""
         # --- sample function around root -----------------
         # n_samples = 2 * n_samples_per_side = 2 * (3 + 6*k) = 6 + 12*k

--- a/snuffled/_core/analysis/snuffler.py
+++ b/snuffled/_core/analysis/snuffler.py
@@ -32,7 +32,7 @@ class Snuffler(PropertyExtractor[SnuffledProperties]):
         n_roots: int = 100,
         n_root_samples: int = 100,
         rel_tol_scale: float = 10.0,
-    ):
+    ) -> None:
         seed += SEED_OFFSET_SNUFFLER
         function_sampler = FunctionSampler(fun, x_min, x_max, dx, seed, n_fun_samples, n_roots, rel_tol_scale)
         super().__init__(function_sampler)

--- a/snuffled/_core/compatibility/_numba.py
+++ b/snuffled/_core/compatibility/_numba.py
@@ -6,14 +6,14 @@ try:
 
 except ImportError:
     # dummy decorator that will replace numba.jit and numba.njit
-    def dummy_decorator(*args, **kwargs):
+    def dummy_decorator(*args: object, **kwargs: object) -> Callable:
         # dummy decorator that does nothing and can be used with or without arguments
         if len(args) == 1 and isinstance(args[0], Callable):
             # decorator used without arguments
             return args[0]
 
         # decorator used with arguments
-        def decorator(func):
+        def decorator(func: Callable) -> Callable:
             return func
 
         return decorator

--- a/snuffled/_core/models/base/_named_array.py
+++ b/snuffled/_core/models/base/_named_array.py
@@ -4,7 +4,7 @@ class NamedArray:
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
-    def __init__(self, names: list[str], values: list[float] | None = None):
+    def __init__(self, names: list[str], values: list[float] | None = None) -> None:
         """Initialize the NamedArray with names and values.
 
         :param names: List of names (str) for the array elements.
@@ -32,7 +32,7 @@ class NamedArray:
     # -------------------------------------------------------------------------
     #  Overridden methods
     # -------------------------------------------------------------------------
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, NamedArray) and (self._names == other._names) and (self._values == other._values)
 
     # mutable container (see __setitem__): intentionally unhashable
@@ -41,16 +41,16 @@ class NamedArray:
     def __len__(self) -> int:
         return len(self._values)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str | int) -> float:
         return self._values[self._key_to_index(key)]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str | int, value: float) -> None:
         self._values[self._key_to_index(key)] = value
 
     # -------------------------------------------------------------------------
     #  Internals
     # -------------------------------------------------------------------------
-    def _key_to_index(self, key) -> int:
+    def _key_to_index(self, key: str | int) -> int:
         """Convert a key (name or index) to an index.
 
         :param key: The key to convert.

--- a/snuffled/_core/models/properties/_all.py
+++ b/snuffled/_core/models/properties/_all.py
@@ -18,7 +18,7 @@ class SnuffledProperties(NamedArray):
         function_props: SnuffledFunctionProperties | None = None,
         root_props: SnuffledRootProperties | None = None,
         diagnostics: SnuffledDiagnostics | None = None,
-    ):
+    ) -> None:
         super().__init__(names=list(FunctionProperty) + list(RootProperty) + list(Diagnostic))
         if function_props:
             for key, value in function_props.as_dict().items():

--- a/snuffled/_core/models/properties/_diagnostic.py
+++ b/snuffled/_core/models/properties/_diagnostic.py
@@ -11,5 +11,5 @@ class Diagnostic(StrEnum):
 class SnuffledDiagnostics(NamedArray):
     """Object providing detected (snuffled) values for all Diagnostic members."""
 
-    def __init__(self, values: list[float] | None = None):
+    def __init__(self, values: list[float] | None = None) -> None:
         super().__init__(names=list(Diagnostic), values=values)

--- a/snuffled/_core/models/properties/_function.py
+++ b/snuffled/_core/models/properties/_function.py
@@ -13,5 +13,5 @@ class FunctionProperty(StrEnum):
 class SnuffledFunctionProperties(NamedArray):
     """Object providing detected (snuffled) values for all FunctionProperty members."""
 
-    def __init__(self, values: list[float] | None = None):
+    def __init__(self, values: list[float] | None = None) -> None:
         super().__init__(names=list(FunctionProperty), values=values)

--- a/snuffled/_core/models/properties/_root.py
+++ b/snuffled/_core/models/properties/_root.py
@@ -13,5 +13,5 @@ class RootProperty(StrEnum):
 class SnuffledRootProperties(NamedArray):
     """Object providing detected (snuffled) values for all RootProperty members."""
 
-    def __init__(self, values: list[float] | None = None):
+    def __init__(self, values: list[float] | None = None) -> None:
         super().__init__(names=list(RootProperty), values=values)

--- a/snuffled/_core/models/root_analysis/_root.py
+++ b/snuffled/_core/models/root_analysis/_root.py
@@ -34,7 +34,7 @@ class Root:
     fx: float
     fx_max: float
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.x_min > self.x:
             raise ValueError(f"x_min<=x expected; here {self.x_min}>{self.x}")
         if self.x > self.x_max:

--- a/snuffled/_core/utils/noise.py
+++ b/snuffled/_core/utils/noise.py
@@ -11,7 +11,7 @@ def noise_from_float(x: float) -> float:
 
     The function is pseudo-random, but deterministic, based on a hash of the string representation of the float.
     """
-    hex_hash = hashlib.md5(str(x).encode("utf-8")).hexdigest()
+    hex_hash = hashlib.md5(str(x).encode("utf-8"), usedforsecurity=False).hexdigest()
     int_hash = int(hex_hash, 16)
 
     return -1.0 + 2.0 * (int_hash / __SCALE)

--- a/snuffled/_core/utils/sampling.py
+++ b/snuffled/_core/utils/sampling.py
@@ -66,7 +66,7 @@ def get_fixed_sum_exponential_intervals(n: int, tgt_sum: float, dx_min: float) -
 
 
 @numba.njit
-def fit_fixed_sum_exponential_intervals(n: int, tgt_sum: float, dx_min: float) -> float:
+def fit_fixed_sum_exponential_intervals(n: int, tgt_sum: float, dx_min: float) -> float:  # noqa: C901 -- iterative solver with several convergence branches
     """PROBLEM STATEMENT.
 
         This function tries to split an interval of size 'tgt_sum' (=target sum of sub-interval sizes) into 'n'

--- a/tests/analysis/diagnostic/test_diagnostic_no_zeroes_detected.py
+++ b/tests/analysis/diagnostic/test_diagnostic_no_zeroes_detected.py
@@ -36,7 +36,6 @@ def f_quadratic(x: float, c0: float) -> float:
         (partial(f_quadratic, c0=-0.5), 0.0),
         (partial(f_quadratic, c0=-0.9), 0.0),
         (partial(f_quadratic, c0=-0.99), 0.0),
-        (partial(f_quadratic, c0=-0.99), 0.0),
         (partial(f_quadratic, c0=-1.001), 1.0),
         (partial(f_quadratic, c0=-2), 1.0),
     ],


### PR DESCRIPTION
Fourth PR of the v0.1.5 quality-gates stack (stacks on the docstring batch). Widens ruff `select` to the final families (`ANN N PT B S SLF C901`), reaching the full reference rule set.

Mechanical: missing type annotations added; `NamedArray` key/return types filled in; `usedforsecurity=False` set on the non-security md5 in `noise.py`.

Judgment calls (per the plan's behavior-eyeball policy):
- `B905` (`zip(strict=)`) **ignored project-wide** — numba nopython can't take the `strict=` kwarg (same reason as `RUF007`).
- pytest `parametrize` names accepted as csv strings; `pytest.raises` `match=` required only for the broad base exceptions.
- `B019` (`@cache` on `FunctionSampler` methods) **parked** via per-file-ignore and recorded on the behavior track — the fix (instance retention → `cached_property`) is a behavior change, out of scope for lint adoption.
- `B023` verified a false positive (closure used immediately in-iteration) → local noqa; two `C901` hot-path functions → local noqa; one genuine duplicate `parametrize` case removed.

3150 tests pass (−1 = the removed duplicate case); `make lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)