### PR TITLE
feat: ship type information (py.typed) and enable ty

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,15 @@ repos:
         types: [python]
         files: ^(snuffled|tests|notebooks|scripts)/|^\.github/scripts/
         pass_filenames: true
+      - id: ty
+        name: ty check
+        entry: uv run ty check
+        language: system
+        types: [python]
+        # ty is a whole-program checker: a staged-files-only run would miss
+        # cross-module breakage, so it runs the project as configured by
+        # [tool.ty] (not the staged subset) whenever any Python file changes.
+        pass_filenames: false
       - id: uv-lock
         name: uv lock --check
         entry: uv lock --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 <!------------------------------------------------------------------------------------------------->
 
 ### What's New
-/
+- Package now ships type information (`py.typed`) for downstream type checkers
 
 ### Improvements
 /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,15 @@ raises-require-match-for = ["Exception", "BaseException"]  # only the truly broa
 # retention is tracked as a parked behavior item, not silently refactored here.
 "snuffled/_core/analysis/_function_sampler.py" = ["B019"]
 
+[tool.ty.src]
+include = ["snuffled"]
+
+[tool.ty.rules]
+# The numba shim needs `ty: ignore`s that are used only when the optional numba
+# extra is absent from the env; flagging them as unused in the other env would
+# make `ty check` results depend on which extras happen to be installed.
+unused-ignore-comment = "ignore"
+
 [tool.coverage.run]
 source = ["snuffled"]
 

--- a/snuffled/_core/analysis/_function_sampler.py
+++ b/snuffled/_core/analysis/_function_sampler.py
@@ -1,6 +1,7 @@
 import math
 from collections.abc import Callable
 from functools import cache
+from typing import overload
 
 import numpy as np
 
@@ -54,6 +55,10 @@ class FunctionSampler:
     # -------------------------------------------------------------------------
     #  Low-level generic functionality
     # -------------------------------------------------------------------------
+    @overload
+    def f(self, x: float) -> float: ...
+    @overload
+    def f(self, x: list[float]) -> list[float]: ...
     def f(self, x: float | list[float]) -> float | list[float]:
         # simple cached version of fun(x), without size limit (and simpler than lru_cache, so less overhead)
         if isinstance(x, list):

--- a/snuffled/_core/compatibility/_numba.py
+++ b/snuffled/_core/compatibility/_numba.py
@@ -23,4 +23,4 @@ except ImportError:
         jit = dummy_decorator
         njit = dummy_decorator
 
-    numba = Numba
+    numba = Numba  # ty: ignore[invalid-assignment] -- fallback shim replaces the real numba module


### PR DESCRIPTION
Fifth PR of the v0.1.5 quality-gates stack (stacks on the final ruff batch). Adds the PEP 561 `py.typed` marker so downstream type checkers see snuffled's annotations, scopes `ty` to the package via `[tool.ty.src]`, and enables the `ty` pre-commit hook (whole-program, `pass_filenames: false`).

The two pre-existing type errors are resolved properly: `FunctionSampler.f` gains `@overload` signatures (so scalar calls type as `float`), and the numba fallback shim's module reassignment is `ty: ignore`d.

Changelog: *Added — package now ships type information (`py.typed`).*

All 3150 tests pass; `make lint` (now incl. `ty`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)