### PR TITLE
chore: migrate the changelog to Keep a Changelog and add CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,112 +1,59 @@
-# Change Log
+# Changelog
 
-<!------------------------------------------------------------------------------------------------->
-> ## v0.1.5
-> *(unreleased)*
-> > Maintenance.
-<!------------------------------------------------------------------------------------------------->
+All notable changes to this project will be documented in this file.
 
-### What's New
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
 - Package now ships type information (`py.typed`) for downstream type checkers
 
-### Improvements
+### Changed
 - Supported Python versions are now 3.11–3.14 (3.10 dropped, 3.14 added)
+- Now requires numpy ≥ 2.0
 
-### Bug Fixes
+### Deprecated
+
+### Removed
+
+### Fixed
 - Fix broken splash screen CI job by committing a locally generated splash image
 
-### Internal
-/
+### Security
 
-<!------------------------------------------------------------------------------------------------->
-> ## v0.1.4
-> *(2025-11-07)*
-> > CI improvements.
-<!------------------------------------------------------------------------------------------------->
+## 0.1.4 (2025-11-07)
 
-### What's New
-/
-
-### Improvements
+### Changed
 - Improve CI/CD pipeline for efficiency
 - Improve splash screen setup
 - Move to trunk-based development workflow with release branches
 
-### Bug Fixes
-/
+## 0.1.3 (2025-10-14)
 
-### Internal
-/
-
-<!------------------------------------------------------------------------------------------------->
-> ## v0.1.3
-> *(2025-10-14)*
-> > Minor bug fix release.
-<!------------------------------------------------------------------------------------------------->
-
-### What's New
-/
-
-### Improvements
+### Changed
 - Improve CI/CD pipeline for efficiency
 - Improve splash screen setup
 
-### Bug Fixes
-/
+## 0.1.2 (2025-10-11)
 
-### Internal
-/
-
-<!------------------------------------------------------------------------------------------------->
-> ## v0.1.2
-> *(2025-10-11)*
-> > Minor bug fix release.
-<!------------------------------------------------------------------------------------------------->
-
-### What's New
+### Added
 - Add Change Log
 
-### Improvements
-/
-
-### Bug Fixes
-/
-
-### Internal
+### Changed
 - Minor tweaks to CI/CD pipeline
 
-<!------------------------------------------------------------------------------------------------->
-> ## v0.1.1
-> *(2025-09-06)*
-> > Minor bug fix release.
-<!------------------------------------------------------------------------------------------------->
+## 0.1.1 (2025-09-06)
 
-### What's New
-/
-
-/
-
-### Bug Fixes
-/
-
-### Internal
+### Changed
 - Minor tweaks to CI/CD pipeline
 
-<!------------------------------------------------------------------------------------------------->
-> ## v0.1.0
-> *(2025-09-06)*
-> > First feature-complete package implementation.
-<!------------------------------------------------------------------------------------------------->
+## 0.1.0 (2025-09-06)
 
-### What's New
+### Added
 - Initial feature-complete version
 - Full test suite & automatic badge generation for README.md
 
-### Improvements
-/
-
-### Bug Fixes
-/
-
-### Internal
+### Changed
 - Initial CI/CD pipeline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to snuffled
+
+Thanks for your interest in contributing.
+
+## Dev setup
+
+One-time setup on a fresh clone:
+
+```bash
+make dev-setup
+```
+
+This syncs dev dependencies via `uv` and installs the pre-commit hooks.
+
+## Common commands
+
+```bash
+make test    # Run the test suite (pytest)
+make format  # Format and auto-fix with ruff
+make lint    # Run all pre-commit hooks (ruff, ty, file hygiene, ...) over all files
+```
+
+## Branching
+
+Branch names follow the pattern:
+
+```
+<prefix>/<short-slug>
+```
+
+- **Prefix** — one of `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+  CI rejects anything else.
+- **Slug** — short kebab-case description: lowercase letters, digits, and
+  hyphens only.
+
+Examples: `feat/yaml-input`, `fix/root-width-crash`, `chore/bump-numpy`.
+
+## Pull requests
+
+PRs are merged into `main` via **squash merge only** (repo settings disable
+merge commits and rebase merges). Each PR therefore produces exactly one commit
+on `main`. The squash commit subject is the PR title, so write it with care — it
+becomes the permanent history, and CI checks it against the `<prefix>: <summary>`
+convention below. The feature branch is deleted automatically on merge.
+
+## Commit messages
+
+Subject line uses the same short-form prefixes as branches:
+
+```
+<prefix>: <imperative summary>
+```
+
+- **Prefix** — `feat`, `fix`, `chore`, `docs`, `refactor`, `test`.
+- **Summary** — imperative mood, lowercase, no trailing period.
+
+Examples:
+
+```
+feat: add yaml input parser
+fix: handle empty root interval
+chore: bump numpy floor
+```
+
+## Changelog
+
+Add an entry under the appropriate category in the `## Unreleased` section of
+[`CHANGELOG.md`](CHANGELOG.md) as part of your PR. CI requires this for `feat/`
+and `fix/` branches.
+
+Changelog entries are **user-facing** — write them for someone deciding whether
+to upgrade, not for someone reviewing the implementation. Focus on what changed
+from the user's perspective.
+
+**Keep each entry to a single line.** Avoid verbosity; omit internal details
+(class names, wiring, refactors that don't affect behavior). Expand to a second
+line only when a single line genuinely can't convey what the change is about.


### PR DESCRIPTION
Eighth PR of the v0.1.5 quality-gates stack (stacks on the PR-gate PR). Prepares the release-automation surface.

- `CHANGELOG.md` rewritten into the [Keep a Changelog](https://keepachangelog.com/) format — a categorized `## Unreleased` section over dated `## X.Y.Z` releases — preserving every historical entry, so `release.py` (next PR) can machine-finalize it. Bespoke categories map cleanly (*What's New*→Added, *Improvements*/*Internal*→Changed, *Bug Fixes*→Fixed).
- `CONTRIBUTING.md` added: dev setup, the branch/commit/PR conventions CI enforces, and the single-line user-facing changelog bar.

`make lint` green (docs-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)