### PR TITLE
chore: add OpenSSF Scorecard workflow and badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: Scorecard
+
+# OpenSSF Scorecard: continuously scores the repo's security posture (branch
+# protection, pinned dependencies, SAST presence, signed releases, …) and
+# publishes the result so the README badge stays live. It makes that posture
+# externally visible and tracked; it does not itself change any individual check.
+
+on:
+  workflow_dispatch:        # allow an on-demand re-score from the Actions tab
+  branch_protection_rule:   # re-score when branch-protection settings change
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 3"     # weekly, Wednesday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload SARIF results to code scanning
+      id-token: write         # publish results to the public Scorecard API (OIDC)
+      contents: read          # checkout
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true  # required for the badge + the public scorecard.dev viewer
+      - name: Upload SARIF as an artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/snuffled.svg)](https://pypi.org/project/snuffled/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/bertpl/snuffled/blob/main/LICENSE)
 [![code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230)](https://github.com/astral-sh/ruff)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bertpl/snuffled/badge)](https://scorecard.dev/viewer/?uri=github.com/bertpl/snuffled)
 
 ![snuffled logo](images/splash_with_version.webp)
 


### PR DESCRIPTION
Adds scorecard.yml (weekly, on-demand, on branch-protection changes and main pushes), uploads results to code scanning, and adds the Scorecard badge to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)