### PR TITLE
chore: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+# Static analysis (SAST) for the Python package. Advisory, not blocking:
+# this is an independent security scanner, deliberately NOT part of the
+# `CI gate` aggregation — a code-scanning alert should surface without
+# failing an unrelated PR. Complements zizmor/actionlint (which lint the
+# workflows, not the package code).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 2"  # weekly, Tuesday 06:00 UTC — catches new query packs between PRs
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload analysis results to code scanning
+      contents: read          # checkout
+      actions: read           # read workflow run metadata (CodeQL requirement)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          languages: python  # pure-Python package: no build step, CodeQL analyzes sources directly
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3


### PR DESCRIPTION
Adds codeql.yml: Python SAST on PRs, pushes to main, and weekly. Advisory — alerts surface in code scanning without blocking PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)