### PR TITLE
test: run whole-pipeline tests at honest parameters in the JIT-only tier

### DIFF
--- a/tests/analysis/diagnostic/test_diagnostic_max_zero_width.py
+++ b/tests/analysis/diagnostic/test_diagnostic_max_zero_width.py
@@ -39,7 +39,7 @@ def f_wide_zeroes(x: float, width_left: float, width_right: float) -> float:
         (partial(f_wide_zeroes, width_left=0, width_right=0), 0.0, 2 * EPS),
         (partial(f_wide_zeroes, width_left=1e-3, width_right=1e-6), 8e-4, 1.2e-3),
         (partial(f_wide_zeroes, width_left=1e-9, width_right=1e-4), 8e-5, 1.2e-4),
-        (partial(f_wide_zeroes, width_left=1e-10, width_right=1e-10), 8e-11, 1.2e10),
+        (partial(f_wide_zeroes, width_left=1e-10, width_right=1e-10), 8e-11, 1.2e-10),
     ],
 )
 def test_function_analyser_max_zero_width(fun: Callable[[float], float], max_width_lb: float, max_width_ub: float):

--- a/tests/analysis/function/test_function_many_zeroes.py
+++ b/tests/analysis/function/test_function_many_zeroes.py
@@ -7,6 +7,7 @@ import pytest
 from snuffled._core.analysis import FunctionSampler
 from snuffled._core.analysis.function import FunctionAnalyser
 from snuffled._core.models import FunctionProperty
+from tests.helpers import only_with_numba_jit
 
 
 # =================================================================================================
@@ -27,20 +28,21 @@ def f_sine(x: float, n_roots: int) -> float:
 # =================================================================================================
 #  Main tests
 # =================================================================================================
+@only_with_numba_jit
 @pytest.mark.parametrize(
     "fun, min_score, max_score",
     [
         (f_linear, 0.0, 1e-3),
-        (f_cubic, 0.05, 0.20),
+        (f_cubic, 0.05, 0.10),
         (partial(f_sine, n_roots=1), 0.0, 1e-3),
-        (partial(f_sine, n_roots=3), 0.05, 0.20),
-        (partial(f_sine, n_roots=1000), 0.25, 0.75),
-        (partial(f_sine, n_roots=1e9), 0.95, 1.00),
+        (partial(f_sine, n_roots=3), 0.05, 0.10),
+        (partial(f_sine, n_roots=1000), 0.45, 0.55),
+        (partial(f_sine, n_roots=1e9), 0.99, 1.00),
     ],
 )
 def test_function_analyser_many_zeroes(fun: Callable[[float], float], min_score: float, max_score: float):
     # --- arrange -----------------------------------------
-    sampler = FunctionSampler(fun=fun, x_min=-1.0, x_max=1.0, dx=1e-6, seed=42, n_fun_samples=1000)
+    sampler = FunctionSampler(fun=fun, x_min=-1.0, x_max=1.0, dx=1e-6, seed=42, n_fun_samples=10_000)
     analyser = FunctionAnalyser(sampler)
 
     # --- act ---------------------------------------------

--- a/tests/analysis/test_snuffler.py
+++ b/tests/analysis/test_snuffler.py
@@ -2,6 +2,7 @@ import time
 
 from snuffled import Diagnostic, FunctionProperty, Snuffler
 from snuffled._core.models import RootProperty
+from tests.helpers import only_with_numba_jit
 
 
 def test_snuffler_supported_properties():
@@ -25,6 +26,36 @@ def test_snuffler_supported_properties():
     assert set(supported_properties) == set(list(RootProperty) + list(Diagnostic) + list(FunctionProperty))
 
 
+def test_snuffler_extract_all_smoke():
+    """Fast, deterministic structural check of extract_all()/statistics() at tiny sample counts.
+
+    Carries the line coverage of the whole-pipeline tests below, which only run under JIT;
+    the parameters are chosen purely for speed, not statistical honesty — no score values
+    are asserted here.
+    """
+    # --- arrange -----------------------------------------
+    snuffler = Snuffler(
+        fun=lambda x: x,
+        x_min=-1.0,
+        x_max=1.0,
+        dx=1e-10,
+        seed=42,
+        n_fun_samples=100,
+        n_roots=10,
+        n_root_samples=10,
+        rel_tol_scale=10.0,
+    )
+
+    # --- act ---------------------------------------------
+    _ = snuffler.extract_all()
+    stats = snuffler.statistics()
+
+    # --- assert ------------------------------------------
+    assert len(stats) == len(RootProperty) + len(Diagnostic) + len(FunctionProperty)
+    assert all(s.t_duration_sec >= 0 for s in stats.values())
+
+
+@only_with_numba_jit
 def test_snuffler_extract_all():
     # --- arrange -----------------------------------------
     snuffler = Snuffler(
@@ -33,19 +64,16 @@ def test_snuffler_extract_all():
         x_max=1.0,
         dx=1e-10,
         seed=42,
-        n_fun_samples=1000,
-        n_roots=100,
-        n_root_samples=100,
-        rel_tol_scale=10.0,
     )
 
     # --- act ---------------------------------------------
     _ = snuffler.extract_all()
 
     # --- assert ------------------------------------------
-    # if it doesn't fail, that's good enough for this test
+    # if it doesn't fail at production-default sample counts, that's good enough for this test
 
 
+@only_with_numba_jit
 def test_snuffler_statistics():
     # --- arrange -----------------------------------------
     snuffler = Snuffler(
@@ -54,10 +82,6 @@ def test_snuffler_statistics():
         x_max=1.0,
         dx=1e-10,
         seed=42,
-        n_fun_samples=1000,
-        n_roots=100,
-        n_root_samples=100,
-        rel_tol_scale=10.0,
     )
 
     # --- act ---------------------------------------------


### PR DESCRIPTION
The triage sweep over the suite found most metric tests already assert tight bounds at production-default parameters; the tests actually sized to the old "must stay fast without numba" ceiling were the many-zeroes metric tests and the snuffler `extract_all`/`statistics` pipeline tests. Those now carry `@only_with_numba_jit` and run at production-scale parameters, with bounds re-tightened empirically (7 seeds, set with margin):

| case | old bounds | @10k samples, 7 seeds | new bounds |
|---|---|---|---|
| many_zeroes: cubic | 0.05–0.20 | 0.0697 (all seeds) | 0.05–0.10 |
| many_zeroes: sine, 3 roots | 0.05–0.20 | 0.0697 (all seeds) | 0.05–0.10 |
| many_zeroes: sine, 1000 roots | 0.25–0.75 | 0.5001–0.5008 | 0.45–0.55 |
| many_zeroes: sine, 1e9 roots | 0.95–1.00 | 1.0 (all seeds) | 0.99–1.00 |

A fast structural smoke test (tiny sample counts, asserts schema not scores, ~0.01 s) backfills the snuffler line coverage on JIT-off legs — coverage there stays exactly 98.32%, unchanged from before the moves.

Also fixes a `max_zero_width` upper bound that read `1.2e10` where `1.2e-10` was intended (measured 1.06–1.10e-10 across 7 seeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)