### PR TITLE
chore: add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported versions
+
+snuffled is pre-1.0 and ships frequent releases. Security fixes land in a
+new release on top of the latest published version; older versions are not
+patched in place.
+
+| Version          | Supported          |
+| ---------------- | ------------------ |
+| latest release   | :white_check_mark: |
+| any earlier      | :x:                |
+
+Always upgrade to the most recent release on
+[PyPI](https://pypi.org/project/snuffled/) to receive security fixes.
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public issue,
+discussion, or pull request for a suspected vulnerability.
+
+Use GitHub's [Private Vulnerability Reporting](https://github.com/bertpl/snuffled/security/advisories/new)
+to open a confidential advisory. This is the only supported reporting channel;
+the project publishes no maintainer email address.
+
+When reporting, please include:
+
+- the snuffled version and Python version,
+- a description of the issue and its impact,
+- a minimal input or set of steps that reproduces it.
+
+## What to expect
+
+This is a solo-maintained project, so responses are best-effort:
+
+- **Acknowledgment** within 7 days.
+- **Initial assessment** (confirmed / needs-more-info / not-a-vulnerability)
+  within 14 days.
+- A fix released as soon as practical once an issue is confirmed, with the
+  advisory published alongside it.
+
+Please allow a reasonable window for a fix before any public disclosure.
+Coordinated disclosure is appreciated, and reporters are credited in the
+published advisory unless they prefer to remain anonymous.


### PR DESCRIPTION
Adds `SECURITY.md` following the same policy as the sibling projects: latest-release-only support (pre-1.0), GitHub Private Vulnerability Reporting as the sole reporting channel, and best-effort response expectations for a solo-maintained project. Private Vulnerability Reporting has been enabled in the repo settings to match. Also satisfies the OpenSSF Scorecard **Security-Policy** check, which was docking a point for the missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)