### PR TITLE
fix: return 0.0 max-zero-width for rootless functions instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- `extract_all()` no longer crashes on functions with no root in the interval (e.g. `1 + x²`)
 
 ### Security
 

--- a/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
+++ b/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
@@ -54,7 +54,9 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
         return 1.0
 
     def _extract_max_zero_width(self) -> float:
-        return max([root.width for root in self.function_sampler.roots()])
+        # default=0.0 for rootless functions: no roots -> no zero-width interval,
+        # mirroring the RootsAnalyser no-roots contract (all root properties 0.0).
+        return max((root.width for root in self.function_sampler.roots()), default=0.0)
 
     def _extract_no_zeros_detected(self) -> float:
         root_intervals, _no_root_intervals = self.function_sampler.candidate_root_intervals()

--- a/tests/analysis/diagnostic/test_diagnostic_max_zero_width.py
+++ b/tests/analysis/diagnostic/test_diagnostic_max_zero_width.py
@@ -52,3 +52,35 @@ def test_function_analyser_max_zero_width(fun: Callable[[float], float], max_wid
 
     # --- assert ------------------------------------------
     assert max_width_lb <= max_width <= max_width_ub
+
+
+# =================================================================================================
+#  Rootless functions: empty root list -> 0.0  (regression: used to crash on max() of empty)
+# =================================================================================================
+def f_parabola(x: float) -> float:
+    return 1.0 + x * x  # strictly positive on [-1, 1] -> no root
+
+
+def f_constant(x: float) -> float:
+    return 1.0
+
+
+def f_monotone_no_root(x: float) -> float:
+    return x + 5.0  # no root in [-1, 1]
+
+
+def f_all_zeros(x: float) -> float:
+    return 0.0  # never crosses zero -> no sign-flip root detected
+
+
+@pytest.mark.parametrize("fun", [f_parabola, f_constant, f_monotone_no_root, f_all_zeros])
+def test_max_zero_width_rootless_is_zero(fun: Callable[[float], float]):
+    # --- arrange -----------------------------------------
+    sampler = FunctionSampler(fun=fun, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=1000, rel_tol_scale=10.0)
+    analyser = DiagnosticAnalyser(sampler)
+
+    # --- act ---------------------------------------------
+    max_width = analyser.extract(Diagnostic.MAX_ZERO_WIDTH)
+
+    # --- assert ------------------------------------------
+    assert max_width == 0.0

--- a/tests/analysis/test_snuffler.py
+++ b/tests/analysis/test_snuffler.py
@@ -1,8 +1,38 @@
 import time
+from collections.abc import Callable
+
+import numpy as np
+import pytest
 
 from snuffled import Diagnostic, FunctionProperty, Snuffler
 from snuffled._core.models import RootProperty
 from tests.helpers import only_with_numba_jit
+
+
+# =================================================================================================
+#  Rootless functions complete extract_all() with all-finite scores (regression R1)
+# =================================================================================================
+# NOTE: the *flat* rootless functions (constant, all-zeros) additionally need the flat-function
+# discontinuity guard, so they are exercised at pipeline level once that lands; here we cover the
+# non-flat rootless functions, which the empty-roots fix alone makes crash-free.
+@pytest.mark.parametrize(
+    "fun",
+    [
+        lambda x: 1.0 + x * x,  # parabola, no root
+        lambda x: x + 5.0,  # monotone, no root in [-1, 1]
+    ],
+)
+def test_snuffler_extract_all_rootless(fun: Callable[[float], float]):
+    # --- arrange -----------------------------------------
+    snuffler = Snuffler(
+        fun=fun, x_min=-1.0, x_max=1.0, dx=1e-10, seed=42, n_fun_samples=1000, n_roots=100, n_root_samples=100
+    )
+
+    # --- act ---------------------------------------------
+    props = snuffler.extract_all()
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isfinite(props.as_array()))
 
 
 def test_snuffler_supported_properties():


### PR DESCRIPTION
`extract_all()` crashed with `ValueError: max() iterable argument is empty` on any function with no root in the interval (e.g. `1 + x²`) — `_extract_max_zero_width` took `max()` over an empty root list. It now returns `0.0` on empty roots, mirroring the `RootsAnalyser` no-roots contract.

Regression tests cover the rootless family (parabola, constant, monotone-no-root, all-zeros) at the `max_zero_width` unit level, plus the non-flat rootless functions at the `extract_all()` pipeline level (the flat ones additionally need the flat-function discontinuity guard landing next in the stack).

First of the v0.1.8 robustness stack (audit P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)