### PR TITLE
feat: skip near-edge roots and flag them instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- `ALL_ROOTS_TOO_CLOSE_TO_EDGE` diagnostic — flags functions whose every root is too close to an interval edge to analyze reliably
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `extract_all()` no longer crashes on functions with no root in the interval (e.g. `1 + x²`)
 - `extract_all()` no longer crashes on flat / constant functions
+- `extract_all()` no longer crashes on roots very close to an interval edge (such roots are excluded from analysis)
 
 ### Security
 

--- a/snuffled/_core/analysis/_function_sampler.py
+++ b/snuffled/_core/analysis/_function_sampler.py
@@ -9,7 +9,7 @@ from snuffled._core.models.root_analysis import Root
 from snuffled._core.utils.constants import EPS, SEED_OFFSET_FUNCTION_SAMPLER
 from snuffled._core.utils.math import smooth_sign_array
 from snuffled._core.utils.root_finding import find_odd_root
-from snuffled._core.utils.sampling import multi_scale_samples, sample_integers
+from snuffled._core.utils.sampling import max_x_delta, multi_scale_samples, sample_integers
 
 
 class FunctionSampler:
@@ -255,3 +255,15 @@ class FunctionSampler:
             )
             for x_min, x_max in cand_intervals
         ]
+
+    @cache
+    def analyzable_roots(self) -> list[Root]:
+        """Roots far enough from the interval edges for reliable two-sided analysis.
+
+        A root is analyzable only if both sides have room for the full sampling span
+        `max_x_delta(dx)`; nearer the edge, sampling `root.x ± x_delta` would fall outside
+        `[x_min, x_max]`. Scoped to two-sided root analysis — `roots()` still returns every root
+        (for counting, zero-width, and the all-too-close diagnostic).
+        """
+        margin = max_x_delta(self.dx)
+        return [root for root in self.roots() if (root.x - self.x_min >= margin) and (self.x_max - root.x >= margin)]

--- a/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
+++ b/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
@@ -21,6 +21,7 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
             Diagnostic.INTERVAL_NOT_BRACKETING_READY,
             Diagnostic.NO_ZEROS_DETECTED,
             Diagnostic.MAX_ZERO_WIDTH,
+            Diagnostic.ALL_ROOTS_TOO_CLOSE_TO_EDGE,
         ]
 
     def _new_named_array(self) -> SnuffledDiagnostics:
@@ -34,6 +35,8 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
                 return self._extract_max_zero_width()
             case Diagnostic.NO_ZEROS_DETECTED:
                 return self._extract_no_zeros_detected()
+            case Diagnostic.ALL_ROOTS_TOO_CLOSE_TO_EDGE:
+                return self._extract_all_roots_too_close_to_edge()
             case _:
                 raise ValueError(f"Property {prop} not supported")
 
@@ -64,3 +67,10 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
             # no candidate intervals to find roots
             return 1.0
         return 0.0
+
+    def _extract_all_roots_too_close_to_edge(self) -> float:
+        # 1.0 iff roots exist but every one is too close to an interval edge to analyze reliably
+        # (distinct from NO_ZEROS_DETECTED, which flags the genuinely rootless case).
+        has_roots = len(self.function_sampler.roots()) > 0
+        has_analyzable = len(self.function_sampler.analyzable_roots()) > 0
+        return 1.0 if (has_roots and not has_analyzable) else 0.0

--- a/snuffled/_core/analysis/roots/roots_analyser.py
+++ b/snuffled/_core/analysis/roots/roots_analyser.py
@@ -47,7 +47,9 @@ class RootsAnalyser(PropertyExtractor[SnuffledRootProperties]):
     #  Internal methods
     # -------------------------------------------------------------------------
     def _ensure_all_roots_analysed(self) -> None:
-        roots = self.function_sampler.roots()
+        # only roots with room for the full sampling span on both sides — near-edge roots can't be
+        # reliably two-side-fitted and are flagged by the ALL_ROOTS_TOO_CLOSE_TO_EDGE diagnostic.
+        roots = self.function_sampler.analyzable_roots()
         if len(self._root_analyses) < len(roots):
             self._root_analyses = {
                 root: SingleRootTwoSideAnalyser(

--- a/snuffled/_core/models/properties/_diagnostic.py
+++ b/snuffled/_core/models/properties/_diagnostic.py
@@ -7,6 +7,7 @@ class Diagnostic(StrEnum):
     MAX_ZERO_WIDTH = "diagnostic_max_zero_width"
     NO_ZEROS_DETECTED = "diagnostic_no_zeros_detected"
     INTERVAL_NOT_BRACKETING_READY = "diagnostic_interval_not_bracketing_ready"
+    ALL_ROOTS_TOO_CLOSE_TO_EDGE = "diagnostic_all_roots_too_close_to_edge"
 
 
 class SnuffledDiagnostics(NamedArray):

--- a/snuffled/_core/utils/sampling.py
+++ b/snuffled/_core/utils/sampling.py
@@ -7,6 +7,22 @@ from .constants import SEED_OFFSET_MULTI_SCALE_SAMPLES, SEED_OFFSET_PSEUDO_UNIFO
 
 
 # =================================================================================================
+#  Root-sampling geometry
+# =================================================================================================
+def max_x_delta(dx: float) -> float:
+    """Largest x_delta `compute_x_deltas` can produce for a given dx: `2^2.5 · dx = 4·√2·dx`.
+
+    This is the outer radius of that function's sampling span `[2^-0.5·dx, 2^2.5·dx]`, independent
+    of `k` and `seed` (which only vary sample density/order within the span). Used to decide which
+    roots sit far enough from the interval edges to have room for the full span on both sides. A
+    consistency test pins it against `max(compute_x_deltas(...))` so a span change can't silently
+    drift. Lives here (not next to `compute_x_deltas`) so `FunctionSampler` can use it without a
+    dependency cycle through the roots package.
+    """
+    return (2.0**2.5) * dx
+
+
+# =================================================================================================
 #  Multi-scale sampling
 # =================================================================================================
 @numba.njit

--- a/tests/analysis/roots/test_near_edge_roots.py
+++ b/tests/analysis/roots/test_near_edge_roots.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+
+from snuffled import Diagnostic, Snuffler
+from snuffled._core.analysis import FunctionSampler
+from snuffled._core.models import RootProperty
+
+
+# =================================================================================================
+#  Test functions
+# =================================================================================================
+def _mixed_roots(x: float) -> float:
+    # roots at -1 + 2e-9 (near edge) plus 0.0 and 0.5 (interior)
+    return (x - (-1.0 + 2e-9)) * x * (x - 0.5)
+
+
+# =================================================================================================
+#  analyzable_roots(): near-edge roots excluded, interior roots kept
+# =================================================================================================
+def test_analyzable_roots_excludes_near_edge_root():
+    # --- arrange / act -----------------------------------
+    # root at -1 + 2e-9, well inside the 4*sqrt(2)*dx (~= 5.66e-9) margin
+    sampler = FunctionSampler(
+        fun=lambda x: x - (-1.0 + 2e-9), x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=1000, n_roots=100
+    )
+
+    # --- assert ------------------------------------------
+    assert len(sampler.roots()) > 0  # the root IS detected ...
+    assert len(sampler.analyzable_roots()) == 0  # ... but excluded from two-sided analysis
+
+
+def test_analyzable_roots_keeps_interior_root():
+    # --- arrange / act -----------------------------------
+    sampler = FunctionSampler(
+        fun=lambda x: x - 0.3, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=1000, n_roots=100
+    )
+
+    # --- assert ------------------------------------------
+    assert len(sampler.analyzable_roots()) == len(sampler.roots()) == 1
+
+
+# =================================================================================================
+#  Pipeline: near-edge roots no longer crash + diagnostic / fallback (regression R2)
+# =================================================================================================
+@pytest.mark.parametrize("root_x", [-1.0 + 2e-9, 1.0 - 2e-9])  # both edges
+def test_extract_all_near_edge_root_completes(root_x: float):
+    # --- act ---------------------------------------------
+    props = Snuffler(
+        fun=lambda x: x - root_x,
+        x_min=-1.0,
+        x_max=1.0,
+        dx=1e-9,
+        seed=42,
+        n_fun_samples=1000,
+        n_roots=100,
+        n_root_samples=100,
+    ).extract_all()
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isfinite(props.as_array()))
+    assert props[Diagnostic.ALL_ROOTS_TOO_CLOSE_TO_EDGE] == 1.0  # only root is near an edge
+    assert all(props[rp] == 0.0 for rp in RootProperty)  # no analyzable roots -> 0.0 fallback
+
+
+def test_extract_all_mixed_roots_analyzes_interior():
+    # --- act ---------------------------------------------
+    props = Snuffler(
+        fun=_mixed_roots, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=1000, n_roots=100, n_root_samples=100
+    ).extract_all()
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isfinite(props.as_array()))
+    assert props[Diagnostic.ALL_ROOTS_TOO_CLOSE_TO_EDGE] == 0.0  # interior roots ARE analyzable

--- a/tests/models/properties/test_all.py
+++ b/tests/models/properties/test_all.py
@@ -13,7 +13,7 @@ def test_snuffled_properties_construction_extraction_getters():
     # --- arrange -----------------------------------------
     sfp = SnuffledFunctionProperties([1, 2, 3, 4, 5])
     srp = SnuffledRootProperties([11, 12, 13, 14, 15])
-    sdp = SnuffledDiagnostics([21, 22, 23])
+    sdp = SnuffledDiagnostics([21, 22, 23, 24])
 
     # --- act ---------------------------------------------
     sp = SnuffledProperties(

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -3,13 +3,30 @@ import math
 import numpy as np
 import pytest
 
+from snuffled._core.analysis.roots.curve_fitting import compute_x_deltas
 from snuffled._core.utils.sampling import (
     fit_fixed_sum_exponential_intervals,
     get_fixed_sum_exponential_intervals,
+    max_x_delta,
     multi_scale_samples,
     pseudo_uniform_samples,
     sample_integers,
 )
+
+
+# =================================================================================================
+#  max_x_delta anti-drift: must equal the actual max of compute_x_deltas, for all k / seed / dx
+# =================================================================================================
+@pytest.mark.parametrize("dx", [1.0, 1e-6, 1e-9])
+@pytest.mark.parametrize("k", [1, 2, 5, 10])
+@pytest.mark.parametrize("seed", [1, 42, 999])
+def test_max_x_delta_matches_compute_x_deltas(dx: float, k: int, seed: int) -> None:
+    # --- act ---------------------------------------------
+    claimed = max_x_delta(dx)
+    actual = float(np.max(compute_x_deltas(dx=dx, k=k, seed=seed)))
+
+    # --- assert ------------------------------------------
+    assert claimed == pytest.approx(actual, rel=1e-12)
 
 
 # =================================================================================================


### PR DESCRIPTION
`extract_all()` crashed with `ValueError: x=… out of bounds` when a root sat within the root-sampling span of an interval edge — `SingleRootTwoSideAnalyser` samples `f(root ± x_delta)`, which fell outside `[x_min, x_max]`.

Rather than clamp the samples (which would corrupt the position-sensitive one-sided curve fit — samples would be mispaired with the edge value), **only roots with room for the full sampling span on both sides are analyzed**. `max_x_delta(dx) = 4·√2·dx` (the sampling span's outer radius, verified against `compute_x_deltas` by an anti-drift test) sets the margin; `FunctionSampler.analyzable_roots()` is the scoped subset — `roots()`, `max_zero_width`, and root counts still see every root.

A new **`ALL_ROOTS_TOO_CLOSE_TO_EDGE`** diagnostic fires when roots exist but none are analyzable (distinct from `NO_ZEROS_DETECTED`, the genuinely-rootless case), so downstream can reject such functions. Multiple roots with only some near the edge are analyzed on the interior subset.

Stacked on the flat-discontinuity fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)