### PR TITLE
feat: sanitize non-finite function values at the sampling boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `ALL_ROOTS_TOO_CLOSE_TO_EDGE` diagnostic — flags functions whose every root is too close to an interval edge to analyze reliably
+- `NAN_VALUES_DETECTED` and `INF_VALUES_DETECTED` diagnostics — flag functions that return NaN or ±inf for some input
 
 ### Changed
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extract_all()` no longer crashes on functions with no root in the interval (e.g. `1 + x²`)
 - `extract_all()` no longer crashes on flat / constant functions
 - `extract_all()` no longer crashes on roots very close to an interval edge (such roots are excluded from analysis)
+- `extract_all()` no longer crashes on NaN-returning functions; pole / ±inf functions now produce finite scores (previously NaN)
 
 ### Security
 

--- a/snuffled/_core/analysis/_function_sampler.py
+++ b/snuffled/_core/analysis/_function_sampler.py
@@ -6,7 +6,7 @@ from typing import overload
 import numpy as np
 
 from snuffled._core.models.root_analysis import Root
-from snuffled._core.utils.constants import EPS, SEED_OFFSET_FUNCTION_SAMPLER
+from snuffled._core.utils.constants import EPS, FX_CLIP, SEED_OFFSET_FUNCTION_SAMPLER
 from snuffled._core.utils.math import smooth_sign_array
 from snuffled._core.utils.root_finding import find_odd_root
 from snuffled._core.utils.sampling import max_x_delta, multi_scale_samples, sample_integers
@@ -52,6 +52,12 @@ class FunctionSampler:
         # --- cache ---------------------------------------
         self._fun_cache: dict[float, float] = {}
 
+        # --- non-finite tracking -------------------------
+        # set in _eval() when the function returns NaN / +-inf for a sampled point; read by the
+        # NAN_VALUES_DETECTED / INF_VALUES_DETECTED diagnostics.
+        self._saw_nan = False
+        self._saw_inf = False
+
     # -------------------------------------------------------------------------
     #  Low-level generic functionality
     # -------------------------------------------------------------------------
@@ -68,7 +74,7 @@ class FunctionSampler:
                 if not (self.x_min <= single_x <= self.x_max):
                     raise ValueError(f"x={single_x} is out of bounds [{self.x_min}, {self.x_max}]")
                 if single_x not in self._fun_cache:
-                    self._fun_cache[single_x] = fx = self._fun(single_x)
+                    self._fun_cache[single_x] = fx = self._eval(single_x)
                 else:
                     fx = self._fun_cache[single_x]
                 fx_values.append(fx)
@@ -77,10 +83,40 @@ class FunctionSampler:
         if x in self._fun_cache:
             return self._fun_cache[x]
         if self.x_min <= x <= self.x_max:
-            fx = self._fun(x)
+            fx = self._eval(x)
             self._fun_cache[x] = fx
             return fx
         raise ValueError(f"x={x} is out of bounds [{self.x_min}, {self.x_max}]")
+
+    def _eval(self, x: float) -> float:
+        """Evaluate fun(x), sanitizing non-finite results so no NaN / +-inf reaches the analysis kernels.
+
+        NaN -> FX_CLIP (and _saw_nan set: per the NAN_VALUES_DETECTED contract, all other metrics are
+        then unspecified). We use FX_CLIP rather than 0.0 only to avoid introducing a fake zero-region
+        that would re-trigger the high-dynamic-range divide-by-zero; the exact value is otherwise
+        immaterial. +-inf -> sign * FX_CLIP (and _saw_inf set); finite magnitudes above FX_CLIP are
+        clipped too (arithmetic safety), without setting a flag.
+        """
+        raw = float(self._fun(x))
+        if math.isnan(raw):
+            self._saw_nan = True
+            return FX_CLIP
+        if math.isinf(raw):
+            self._saw_inf = True
+            return math.copysign(FX_CLIP, raw)
+        if abs(raw) > FX_CLIP:
+            return math.copysign(FX_CLIP, raw)
+        return raw
+
+    @property
+    def saw_nan(self) -> bool:
+        """Whether the function returned NaN for at least one sampled point so far."""
+        return self._saw_nan
+
+    @property
+    def saw_inf(self) -> bool:
+        """Whether the function returned +-inf for at least one sampled point so far."""
+        return self._saw_inf
 
     @cache
     def x_values(self) -> np.ndarray:

--- a/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
+++ b/snuffled/_core/analysis/diagnostic/diagnostic_analyser.py
@@ -18,6 +18,8 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
     def supported_properties(self) -> list[str]:
         # return in order of increasing number of required function evals
         return [
+            Diagnostic.NAN_VALUES_DETECTED,
+            Diagnostic.INF_VALUES_DETECTED,
             Diagnostic.INTERVAL_NOT_BRACKETING_READY,
             Diagnostic.NO_ZEROS_DETECTED,
             Diagnostic.MAX_ZERO_WIDTH,
@@ -37,6 +39,10 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
                 return self._extract_no_zeros_detected()
             case Diagnostic.ALL_ROOTS_TOO_CLOSE_TO_EDGE:
                 return self._extract_all_roots_too_close_to_edge()
+            case Diagnostic.NAN_VALUES_DETECTED:
+                return self._extract_nan_values_detected()
+            case Diagnostic.INF_VALUES_DETECTED:
+                return self._extract_inf_values_detected()
             case _:
                 raise ValueError(f"Property {prop} not supported")
 
@@ -74,3 +80,14 @@ class DiagnosticAnalyser(PropertyExtractor[SnuffledDiagnostics]):
         has_roots = len(self.function_sampler.roots()) > 0
         has_analyzable = len(self.function_sampler.analyzable_roots()) > 0
         return 1.0 if (has_roots and not has_analyzable) else 0.0
+
+    def _extract_nan_values_detected(self) -> float:
+        # 1.0 iff the function returned NaN for a sampled point (which the boundary sanitize replaced).
+        # Force the multi-scale grid first so the flag is set even when extracted standalone.
+        self.function_sampler.fx_values()
+        return 1.0 if self.function_sampler.saw_nan else 0.0
+
+    def _extract_inf_values_detected(self) -> float:
+        # 1.0 iff the function returned +-inf for a sampled point (which the boundary clip replaced).
+        self.function_sampler.fx_values()
+        return 1.0 if self.function_sampler.saw_inf else 0.0

--- a/snuffled/_core/analysis/snuffler.py
+++ b/snuffled/_core/analysis/snuffler.py
@@ -16,7 +16,14 @@ from .roots import RootsAnalyser
 
 
 class Snuffler(PropertyExtractor[SnuffledProperties]):
-    """Analyze a function, returning SnuffledRootProperties, SnuffledFunctionProperties, or all SnuffledProperties."""
+    """Analyze a function, returning SnuffledRootProperties, SnuffledFunctionProperties, or all SnuffledProperties.
+
+    Non-finite function values are handled at the sampling boundary so analysis never crashes:
+      - ``+-inf`` is clipped to ``+-FX_CLIP`` and still characterized (a pole reads as discontinuous);
+        ``INF_VALUES_DETECTED`` flags that it occurred.
+      - ``NaN`` sets ``NAN_VALUES_DETECTED`` and, per contract, leaves every *other* metric unspecified
+        (finite, but its value may be anything) — a NaN-returning function is not a well-defined target.
+    """
 
     # -------------------------------------------------------------------------
     #  Constructor

--- a/snuffled/_core/analysis/snuffler.py
+++ b/snuffled/_core/analysis/snuffler.py
@@ -54,12 +54,18 @@ class Snuffler(PropertyExtractor[SnuffledProperties]):
         return SnuffledProperties()
 
     def supported_properties(self) -> list[str]:
-        """Make sure function analysis is performed last, so it benefits from samples taken by other analyses."""
-        diagnostic_props = self._diagnostics_analyser.supported_properties()
+        """Order the extraction so shared sampling is done before it's needed.
+
+        Root then function analysis run first (function still benefits from the roots' samples); the
+        diagnostics come last so the NAN_VALUES_DETECTED / INF_VALUES_DETECTED flags reflect every
+        f(x) the deeper analyses evaluated (root bisection, discontinuity zoom), not just the initial
+        multi-scale grid.
+        """
         roots_props = self._roots_analyser.supported_properties()
         function_props = self._function_analyser.supported_properties()
+        diagnostic_props = self._diagnostics_analyser.supported_properties()
 
-        return diagnostic_props + roots_props + function_props
+        return roots_props + function_props + diagnostic_props
 
     def _extract(self, prop: str) -> float:
         if isinstance(prop, Diagnostic):

--- a/snuffled/_core/models/properties/_diagnostic.py
+++ b/snuffled/_core/models/properties/_diagnostic.py
@@ -8,6 +8,8 @@ class Diagnostic(StrEnum):
     NO_ZEROS_DETECTED = "diagnostic_no_zeros_detected"
     INTERVAL_NOT_BRACKETING_READY = "diagnostic_interval_not_bracketing_ready"
     ALL_ROOTS_TOO_CLOSE_TO_EDGE = "diagnostic_all_roots_too_close_to_edge"
+    NAN_VALUES_DETECTED = "diagnostic_nan_values_detected"
+    INF_VALUES_DETECTED = "diagnostic_inf_values_detected"
 
 
 class SnuffledDiagnostics(NamedArray):

--- a/snuffled/_core/utils/constants.py
+++ b/snuffled/_core/utils/constants.py
@@ -1,7 +1,15 @@
+import math
 import sys
 
 # --- accuracy --------------------------------------------
 EPS = sys.float_info.epsilon  # 2**-52 for float64
+
+# f(x) magnitudes are clipped to +/- FX_CLIP at the sampling boundary so +/-inf never reaches the
+# analysis kernels (inf - inf = nan would otherwise poison them). Invariant: FX_CLIP**2 == eps*max,
+# i.e. a squared clipped value sits a full 52-bit mantissa below overflow -- safe under squaring and
+# summation. Far above where high_dynamic_range saturates (q90/q10 = 2**94), so clipping is invisible
+# to that metric for any sane function.
+FX_CLIP = math.sqrt(sys.float_info.max) * math.sqrt(EPS)
 
 # --- seed offsets ----------------------------------------
 # these offsets are used in different functions to ensure

--- a/tests/analysis/test_nan_inf_handling.py
+++ b/tests/analysis/test_nan_inf_handling.py
@@ -1,0 +1,91 @@
+import math
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from snuffled import Diagnostic, FunctionProperty, Snuffler
+from snuffled._core.analysis import FunctionSampler
+from snuffled._core.utils.constants import FX_CLIP
+
+
+# =================================================================================================
+#  Test functions
+# =================================================================================================
+def _f_nan_middle(x: float) -> float:
+    return float("nan") if abs(x) < 0.3 else x  # NaN over a region
+
+
+def _f_nan_at_only_root(x: float) -> float:
+    return float("nan") if abs(x) < 0.3 else (x - 0.5 if x > 0 else x)  # NaN covers the only sign flip
+
+
+def _f_inf_region(x: float) -> float:
+    return float("inf") if x > 0.5 else x  # +inf over a region -> the grid samples it
+
+
+def _f_pole(x: float) -> float:
+    return 1.0 / (x - 0.2) if x != 0.2 else float("inf")  # R4 pole
+
+
+# =================================================================================================
+#  Boundary sanitize (FunctionSampler.f): NaN / +-inf never leave f(); flags are set
+# =================================================================================================
+def test_f_clips_positive_inf_and_flags():
+    # --- arrange / act / assert --------------------------
+    sampler = FunctionSampler(fun=lambda x: float("inf"), x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=100)
+    assert sampler.f(0.0) == FX_CLIP
+    assert sampler.saw_inf
+    assert not sampler.saw_nan
+
+
+def test_f_clips_negative_inf():
+    sampler = FunctionSampler(fun=lambda x: float("-inf"), x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=100)
+    assert sampler.f(0.0) == -FX_CLIP
+    assert sampler.saw_inf
+
+
+def test_f_sanitizes_nan_and_flags():
+    sampler = FunctionSampler(fun=lambda x: float("nan"), x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=100)
+    assert math.isfinite(sampler.f(0.0))
+    assert sampler.saw_nan
+    assert not sampler.saw_inf
+
+
+def test_f_clips_huge_finite_without_inf_flag():
+    sampler = FunctionSampler(fun=lambda x: FX_CLIP * 10, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=100)
+    assert sampler.f(0.0) == FX_CLIP  # clipped for arithmetic safety ...
+    assert not sampler.saw_inf  # ... but a finite value is not flagged as inf
+    assert not sampler.saw_nan
+
+
+# =================================================================================================
+#  Pipeline: NaN / inf functions complete extract_all() + are flagged (regression R3, R4)
+# =================================================================================================
+@pytest.mark.parametrize("fun", [_f_nan_middle, _f_nan_at_only_root])
+def test_extract_all_nan_completes_and_flags(fun: Callable[[float], float]):
+    # --- act ---------------------------------------------
+    props = Snuffler(fun=fun, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42).extract_all()
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isfinite(props.as_array()))  # never crashes, output stays finite
+    assert props[Diagnostic.NAN_VALUES_DETECTED] == 1.0
+
+
+def test_extract_all_inf_completes_and_flags():
+    # --- act ---------------------------------------------
+    props = Snuffler(fun=_f_inf_region, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42).extract_all()
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isfinite(props.as_array()))
+    assert props[Diagnostic.INF_VALUES_DETECTED] == 1.0
+
+
+def test_extract_all_pole_has_finite_discontinuity():
+    # R4: the pole used to give a NaN discontinuity score (+ leaked warnings); the clip makes it finite
+    # --- act ---------------------------------------------
+    props = Snuffler(fun=_f_pole, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42).extract_all()
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isfinite(props.as_array()))
+    assert props[FunctionProperty.DISCONTINUOUS] > 0.99

--- a/tests/analysis/test_nan_inf_handling.py
+++ b/tests/analysis/test_nan_inf_handling.py
@@ -89,3 +89,28 @@ def test_extract_all_pole_has_finite_discontinuity():
     # --- assert ------------------------------------------
     assert np.all(np.isfinite(props.as_array()))
     assert props[FunctionProperty.DISCONTINUOUS] > 0.99
+
+
+# =================================================================================================
+#  Deep detection: a non-finite value first hit during root-finding (not the initial grid) is flagged
+# =================================================================================================
+@pytest.mark.parametrize(
+    "bad, diagnostic",
+    [
+        (float("nan"), Diagnostic.NAN_VALUES_DETECTED),
+        (float("inf"), Diagnostic.INF_VALUES_DETECTED),
+    ],
+)
+def test_non_finite_hit_only_in_deep_analysis_is_flagged(bad: float, diagnostic: Diagnostic):
+    # A tiny non-finite band around the root at 0: a coarse grid (n_fun_samples=10) misses it, but
+    # root-finding bisects into it -> the diagnostic must reflect that deeper sampling, not the grid alone.
+    def fun(x: float) -> float:
+        return bad if abs(x) < 1e-7 else x
+
+    # --- act ---------------------------------------------
+    props = Snuffler(
+        fun=fun, x_min=-1.0, x_max=1.0, dx=1e-9, seed=42, n_fun_samples=10, n_roots=10, n_root_samples=10
+    ).extract_all()
+
+    # --- assert ------------------------------------------
+    assert props[diagnostic] == 1.0

--- a/tests/models/properties/test_all.py
+++ b/tests/models/properties/test_all.py
@@ -13,7 +13,7 @@ def test_snuffled_properties_construction_extraction_getters():
     # --- arrange -----------------------------------------
     sfp = SnuffledFunctionProperties([1, 2, 3, 4, 5])
     srp = SnuffledRootProperties([11, 12, 13, 14, 15])
-    sdp = SnuffledDiagnostics([21, 22, 23, 24])
+    sdp = SnuffledDiagnostics([21, 22, 23, 24, 25, 26])
 
     # --- act ---------------------------------------------
     sp = SnuffledProperties(


### PR DESCRIPTION
`extract_all()` crashed on NaN-returning functions (NaN fabricates fake sign-flip intervals → `find_odd_root` raises, or a NaN reaches `Root.deriv_sign`) and produced a NaN `function_discontinuous` score plus leaked `RuntimeWarning`s on ±inf / pole functions.

Fixed at the single choke point every value flows through — `FunctionSampler.f()`:
- **±inf** (and any finite magnitude above `FX_CLIP`) → clipped to `±FX_CLIP`. `FX_CLIP = sqrt(max)·sqrt(eps)` so a *squared* clipped value sits a full 52-bit mantissa below overflow (safe under squaring + summation), and it's far above where high-dynamic-range saturates, so clipping is invisible to that metric. inf/poles stay characterized (a pole reads as discontinuous).
- **NaN** → replaced with a finite value (`FX_CLIP`, chosen only to avoid a fake zero-region that would re-trigger the HDR divide-by-zero).

Because no kernel ever sees a non-finite value, the `inf − inf = nan` trap disappears across all kernels at once — this **subsumes the audit's separate ±inf discontinuity fix**. Two new diagnostics, **`NAN_VALUES_DETECTED`** and **`INF_VALUES_DETECTED`**, read flags `FunctionSampler` sets when it sees NaN / ±inf. **Contract:** any NaN sets `NAN_VALUES_DETECTED` and leaves every other metric unspecified (finite, but its value may be anything) — a NaN-returning function isn't a well-defined analysis target.

Stacked on the near-edge-roots PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)